### PR TITLE
BUILD-6326: add environment as optional input

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,11 +9,16 @@ on:
         description: Channel to post notifications
         default: build
         required: true
+      environment:
+        required: false
+        type: string
+        default: ''
 
 jobs:
  slack-notifications:
   runs-on: ubuntu-latest
   name: ${{ github.event.check_run.name }} Slack Notification
+  environment: ${{ inputs.environment }}
   permissions:
    id-token: write  # to authenticate via OIDC
   if: >-


### PR DESCRIPTION
BUILD-6326: add environment as optional input

This is required in repositories where `environment` is part of the OIDC sub claims. Otherwise the action will throw an error

```
OIDC error: the claim 'environment' cannot be `null` or empty. The following claims specified by the `include_claim_keys` setting must be set: repo, environment, ref. See <https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token> for more information.
```

More info in the ticket.

Tested in https://github.com/SonarSource/sonar-dummy/actions/runs/10996256142/job/30528993844