### PR TITLE
BUILD-6326: add environment name to slack action

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,16 +9,12 @@ on:
         description: Channel to post notifications
         default: build
         required: true
-      environment:
-        required: false
-        type: string
-        default: ''
 
 jobs:
  slack-notifications:
   runs-on: ubuntu-latest
   name: ${{ github.event.check_run.name }} Slack Notification
-  environment: ${{ inputs.environment }}
+  environment: slack
   permissions:
    id-token: write  # to authenticate via OIDC
   if: >-


### PR DESCRIPTION
BUILD-6326: add environment name to slack action

Alternative to https://github.com/SonarSource/gh-action_build-notify/pull/19

Setting the environment name to `slack` is a better solution. GitHub will automatically create an environment `slack` in the repository where this action is used. This way, the change will be transparent to the end user