### PR TITLE
BUILD-7504 get detail from specific triggering event

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -103,7 +103,6 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             /repos/${{ github.repository }}/check-suites/${{ github.event.check_suite.id }}/check-runs \
             | jq '.check_runs[] | select(.conclusion == "failure")' > failed_check_runs.json
-          cat failed_check_runs.json
 
           echo "Extract fields for check-run: $(jq -r '.name' failed_check_runs.json | head -n 1)"
 
@@ -125,49 +124,6 @@ jobs:
           echo "avatar_url=$avatar_url" >> $GITHUB_ENV
           echo "check_suite_id=$check_suite_id" >> $GITHUB_ENV
         fi
-
-    - name: Debug Slack Payload
-      run: |
-        echo "Payload:"
-        echo "check_suite_id: ${{ env.check_suite_id }}"
-        echo "{
-          \"channel\":\"${{ inputs.slackChannel }}\",
-          \"attachments\":[
-              {
-                \"color\":\"#ee0000\",
-                \"blocks\":[
-                    {
-                      \"type\":\"section\",
-                      \"text\":{
-                          \"type\":\"mrkdwn\",
-                          \"text\":\"*${{ env.app_name }}* - <${{ env.details_url }}|${{ env.run_name }}> ${{ env.conclusion }}  in *${{ github.repository }}*\"
-                      }
-                    },
-                    {
-                      \"type\":\"section\",
-                      \"text\":{
-                          \"type\":\"mrkdwn\",
-                          \"text\":\"Branch: *${{ env.head_branch }}*\nCommit: *${{ env.head_sha }}*\nActor: <@${{ env.user_id }}>\"
-                      }
-                    },
-                    {
-                      \"type\": \"context\",
-                      \"elements\": [
-                          {
-                            \"type\": \"image\",
-                            \"image_url\": \"${{ env.avatar_url }}\",
-                            \"alt_text\": \"Icon\"
-                          },
-                          {
-                            \"type\": \"mrkdwn\",
-                            \"text\": \"<${{ env.details_url }}|View more details>\"
-                          }
-                      ]
-                    }
-                ]
-              }
-          ]
-        }"
 
     - name: Send Slack notification
       uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,9 @@ jobs:
   name: ${{ github.event.check_run.name }} Slack Notification
   environment: ${{ inputs.environment }}
   permissions:
-   id-token: write  # to authenticate via OIDC
+    contents: read
+    checks: read
+    id-token: write  # to authenticate via OIDC
   if: >-
       contains(fromJSON('["cirrus-ci", "sonarqube-next", "sonarcloud", "azure-pipelines"]'), github.event.check_run.app.slug)
       && ( contains(fromJSON('["main", "master"]'), github.event.check_run.check_suite.head_branch) || startsWith(github.event.check_run.check_suite.head_branch, 'dogfood-') || startsWith(github.event.check_run.check_suite.head_branch, 'branch-') )
@@ -81,8 +83,11 @@ jobs:
 
     - name: Set Slack Notification Variables
       id: set-slack-vars
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         if [ "${{ github.event_name }}" == "check_run" ]; then
+          echo "event_type=check_run" >> $GITHUB_ENV
           echo "app_name=${{ github.event.check_run.app.name }}" >> $GITHUB_ENV
           echo "details_url=${{ github.event.check_run.details_url }}" >> $GITHUB_ENV
           echo "run_name=${{ github.event.check_run.name }}" >> $GITHUB_ENV
@@ -90,15 +95,79 @@ jobs:
           echo "head_branch=${{ github.event.check_run.check_suite.head_branch }}" >> $GITHUB_ENV
           echo "head_sha=${{ github.event.check_run.head_sha }}" >> $GITHUB_ENV
           echo "avatar_url=${{ github.event.check_run.app.owner.avatar_url }}" >> $GITHUB_ENV
+          echo "check_suite_id=${{ github.event.check_run.check_suite.id }}" >> $GITHUB_ENV
         else
-          echo "app_name=${{ github.event.check_suite.app.name }}" >> $GITHUB_ENV
-          echo "details_url=${{ github.event.check_suite.details_url }}" >> $GITHUB_ENV
-          echo "run_name=${{ github.event.check_suite.name }}" >> $GITHUB_ENV
-          echo "conclusion=${{ github.event.check_suite.conclusion }}" >> $GITHUB_ENV
+          echo "Retrieving failed check runs for check suite ID: ${{ github.event.check_suite.id }}"
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/${{ github.repository }}/check-suites/${{ github.event.check_suite.id }}/check-runs \
+            | jq '.check_runs[] | select(.conclusion == "failure")' > failed_check_runs.json
+          cat failed_check_runs.json
+
+          echo "Extract fields for check-run: $(jq -r '.name' failed_check_runs.json | head -n 1)"
+
+          # Extract fields from the failed check run and set environment variables
+          app_name=$(jq -r '.app.name' failed_check_runs.json | head -n 1)
+          details_url=$(jq -r '.details_url' failed_check_runs.json | head -n 1)
+          run_name=$(jq -r '.name' failed_check_runs.json | head -n 1)
+          conclusion=$(jq -r '.conclusion' failed_check_runs.json | head -n 1)
+          head_sha=$(jq -r '.head_sha' failed_check_runs.json | head -n 1)
+          avatar_url=$(jq -r '.app.owner.avatar_url' failed_check_runs.json | head -n 1)
+          check_suite_id=$(jq -r '.check_suite.id' failed_check_runs.json | head -n 1)
+
+          echo "app_name=$app_name" >> $GITHUB_ENV
+          echo "details_url=$details_url" >> $GITHUB_ENV
+          echo "run_name=$run_name" >> $GITHUB_ENV
+          echo "conclusion=$conclusion" >> $GITHUB_ENV
           echo "head_branch=${{ github.event.check_suite.head_branch }}" >> $GITHUB_ENV
-          echo "head_sha=${{ github.event.check_suite.head_sha }}" >> $GITHUB_ENV
-          echo "avatar_url=${{ github.event.check_suite.app.owner.avatar_url }}" >> $GITHUB_ENV
+          echo "head_sha=$head_sha" >> $GITHUB_ENV
+          echo "avatar_url=$avatar_url" >> $GITHUB_ENV
+          echo "check_suite_id=$check_suite_id" >> $GITHUB_ENV
         fi
+
+    - name: Debug Slack Payload
+      run: |
+        echo "Payload:"
+        echo "check_suite_id: ${{ env.check_suite_id }}"
+        echo "{
+          \"channel\":\"${{ inputs.slackChannel }}\",
+          \"attachments\":[
+              {
+                \"color\":\"#ee0000\",
+                \"blocks\":[
+                    {
+                      \"type\":\"section\",
+                      \"text\":{
+                          \"type\":\"mrkdwn\",
+                          \"text\":\"*${{ env.app_name }}* - <${{ env.details_url }}|${{ env.run_name }}> ${{ env.conclusion }}  in *${{ github.repository }}*\"
+                      }
+                    },
+                    {
+                      \"type\":\"section\",
+                      \"text\":{
+                          \"type\":\"mrkdwn\",
+                          \"text\":\"Branch: *${{ env.head_branch }}*\nCommit: *${{ env.head_sha }}*\nActor: <@${{ env.user_id }}>\"
+                      }
+                    },
+                    {
+                      \"type\": \"context\",
+                      \"elements\": [
+                          {
+                            \"type\": \"image\",
+                            \"image_url\": \"${{ env.avatar_url }}\",
+                            \"alt_text\": \"Icon\"
+                          },
+                          {
+                            \"type\": \"mrkdwn\",
+                            \"text\": \"<${{ env.details_url }}|View more details>\"
+                          }
+                      ]
+                    }
+                ]
+              }
+          ]
+        }"
 
     - name: Send Slack notification
       uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,6 +79,27 @@ jobs:
             core.exportVariable('user_id', '');
           }
 
+    - name: Set Slack Notification Variables
+      id: set-slack-vars
+      run: |
+        if [ "${{ github.event_name }}" == "check_run" ]; then
+          echo "app_name=${{ github.event.check_run.app.name }}" >> $GITHUB_ENV
+          echo "details_url=${{ github.event.check_run.details_url }}" >> $GITHUB_ENV
+          echo "run_name=${{ github.event.check_run.name }}" >> $GITHUB_ENV
+          echo "conclusion=${{ github.event.check_run.conclusion }}" >> $GITHUB_ENV
+          echo "head_branch=${{ github.event.check_run.check_suite.head_branch }}" >> $GITHUB_ENV
+          echo "head_sha=${{ github.event.check_run.head_sha }}" >> $GITHUB_ENV
+          echo "avatar_url=${{ github.event.check_run.app.owner.avatar_url }}" >> $GITHUB_ENV
+        else
+          echo "app_name=${{ github.event.check_suite.app.name }}" >> $GITHUB_ENV
+          echo "details_url=${{ github.event.check_suite.details_url }}" >> $GITHUB_ENV
+          echo "run_name=${{ github.event.check_suite.name }}" >> $GITHUB_ENV
+          echo "conclusion=${{ github.event.check_suite.conclusion }}" >> $GITHUB_ENV
+          echo "head_branch=${{ github.event.check_suite.head_branch }}" >> $GITHUB_ENV
+          echo "head_sha=${{ github.event.check_suite.head_sha }}" >> $GITHUB_ENV
+          echo "avatar_url=${{ github.event.check_suite.app.owner.avatar_url }}" >> $GITHUB_ENV
+        fi
+
     - name: Send Slack notification
       uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
       env:
@@ -96,14 +117,14 @@ jobs:
                         "type":"section",
                         "text":{
                             "type":"mrkdwn",
-                            "text":"*${{ github.event.check_run.app.name }}* - <${{ github.event.check_run.details_url }}|${{ github.event.check_run.name }}> ${{ github.event.check_run.conclusion }}  in *${{ github.repository }}*"
+                            "text":"*${{ env.app_name }}* - <${{ env.details_url }}|${{ env.run_name }}> ${{ env.conclusion }}  in *${{ github.repository }}*"
                         }
                       },
                       {
                         "type":"section",
                         "text":{
                             "type":"mrkdwn",
-                            "text":"Branch: *${{ github.event.check_run.check_suite.head_branch }}*\nCommit: *${{ github.event.check_run.head_sha }}*\nActor: <@${{ env.user_id }}>"
+                            "text":"Branch: *${{ env.head_branch }}*\nCommit: *${{ env.head_sha }}*\nActor: <@${{ env.user_id }}>"
                         }
                       },
                       {
@@ -111,12 +132,12 @@ jobs:
                         "elements": [
                             {
                               "type": "image",
-                              "image_url": "${{ github.event.check_run.app.owner.avatar_url }}",
+                              "image_url": "${{ env.avatar_url }}",
                               "alt_text": "Icon"
                             },
                             {
                               "type": "mrkdwn",
-                              "text": "<${{ github.event.check_run.details_url }}|View more details>"
+                              "text": "<${{ env.details_url }}|View more details>"
                             }
                         ]
                       }

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ on:
 jobs:
   slack-notifications:
     permissions:
+      contents: read
+      checks: read
       id-token: write # to authenticate via OIDC
     uses: SonarSource/gh-action_build-notify/.github/workflows/main.yaml@v2
     with:


### PR DESCRIPTION
This PR fixes the issue when notification is triggered from a check_suite event.
It introduces a breaking change because it needs new permissions to be added to the github token:
``permissions:
    contents: read
    checks: read``